### PR TITLE
Gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# virtualenv stuff
+
 env/
+urlenv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# private_settings should hold all security sensitive items
+# SECRET_KEY, EMail passwords, API keys, etc.
+private_settings.py
+
+# it's bad practice to include the database in version control
+# it's better to write a script that will load the development
+# database with test values
+*.sqlite3

--- a/UrlShortener/settings.py
+++ b/UrlShortener/settings.py
@@ -12,15 +12,14 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
+from private_settings import SECRET_KEY
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.10/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'pf7#1c!o=&9(u5^i2#oaasedm!id=&c$vf+%91@87m*d3nk(__'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/UrlShortener/settings.py
+++ b/UrlShortener/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
-from private_settings import SECRET_KEY
+from private_settings import *
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
I found this project via up-for-grabs.net. I'm new to this whole open-source thing, so bear with me.

I made some changes to keep secrets out of version control to keep them safe. Specifically, I created a private_settings.py that is ignored by .gitignore, and moved the SECRET_KEY into it.

If you're interested, I'd also like to script the addition of test data into the database so contributors can quickly set up a development database in case a migration goes wrong and the db needs to be repopulated.