### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UrlShortener 
-[![forthebadge](http://forthebadge.com/badges/built-with-swag.svg)](http://forthebadge.com)     
+[![forthebadge](https://forthebadge.com/images/badges/built-with-swag.svg)](https://forthebadge.com)     
 [![Build Status](https://travis-ci.org/p53ud0k0d3/UrlShortener.svg?branch=master)](https://travis-ci.org/p53ud0k0d3/UrlShortener)     [![Open Source Love](https://badges.frapsoft.com/os/v1/open-source.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
 
 A Django web app that shortens long urls. User may select from a list of available hosts. 
@@ -46,4 +46,4 @@ For more information: [pytest](https://docs.pytest.org/en/latest/contents.html)
 
 
 ### Adding a new host
-This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](http://www.ellison.rocks/pyshorteners/)
+This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](https://pyshorteners.readthedocs.io/en/latest/)


### PR DESCRIPTION
Previous pull request #34 will not fix the link for pyshorteners because the website no longer exist. I added a alternative url. I also added my own fix for the url forthebadge.