### PR TITLE
Remove goo.gl references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A Django web app that shortens long urls. User may select from a list of availab
 - Tinyurl
 - Is.gd
 - Bit.ly
-- Google URL Shortener
 - Rebrand.ly
 
 ## Pre-reqs

--- a/Shortener/forms.py
+++ b/Shortener/forms.py
@@ -4,12 +4,11 @@ from django import forms
 HOSTS = (
         ('Tinyurl', 'Tinyurl'),
         ('Isgd', 'Is.gd'),
-		    ('Bitly', 'Bit.ly'),
-        ('Google', 'Google URL Shortener'),
+        ('Bitly', 'Bit.ly'),
         ('Rebrandly', 'Rebrand.ly'),
         ('Madwire', 'm360.us'),
         ('Osdb', 'Osdb.link	')
-        )
+)
 
 class Urlform(forms.Form):
     url = forms.CharField(initial='http://',required=True)

--- a/Shortener/tests.py
+++ b/Shortener/tests.py
@@ -11,15 +11,6 @@ from Shortener.views import worker
 # Form tests
 # View tests
 
-def test_worker_shortens_url_with_google():
-    url = "http://7bna.net/wallpapers/cat-pictures.html"
-    host = "Google"
-
-    shortened_url = worker(url, host)
-
-    assert url_validator(shortened_url)
-    assert len(shortened_url) < len(url)
-
 def test_worker_shortens_url_with_bitly():
     url = "http://7bna.net/wallpapers/cat-pictures.html"
     host = "Bitly"

--- a/Shortener/views.py
+++ b/Shortener/views.py
@@ -16,14 +16,11 @@ from pyshorteners.exceptions import UnknownShortenerException
 
 
 BITLY_TOKEN = "19c73c3f96d4b2a64d0337ef7380cf0de313e8f7"
-GOOGLE_TOKEN = "AIzaSyCyj45kuk95kopaSuJ4NvErGMyTVV9i3n4"
 REBRANDLY_TOKEN = "b71d7dcfd2f14f0ca4f533bbd6fd226a"
 
 def worker(url, host):
     if host == "Bitly":
         shortener = Shortener("Bitly", timeout=10, bitly_token=BITLY_TOKEN)
-    elif host == "Google":
-        shortener = Shortener("Google", timeout=10, api_key=GOOGLE_TOKEN)
     elif host == "Rebrandly":
         shortener = Shortener(engine=Rebrandly, timeout=10, api_key=REBRANDLY_TOKEN)
     elif host == "Madwire":


### PR DESCRIPTION
G'day mate,

goo.gl URL shortening was dicontinued in March 2019 as seen [here](https://developers.google.com/url-shortener/) and [here](https://goo.gl/).
I've removed all references to it.

Cheers.