### PR TITLE
Updated documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ For more information: [pytest](https://docs.pytest.org/en/latest/contents.html)
 
 
 ### Adding a new host
-This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](http://www.ellison.rocks/pyshorteners/)
+This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](https://buildmedia.readthedocs.org/media/pdf/pyshorteners/latest/pyshorteners.pdf)


### PR DESCRIPTION
The URL for pyshortners seems to be inactive: http://www.ellison.rocks/pyshorteners

I've replaced it with a documentation link that was released this year: https://buildmedia.readthedocs.org/media/pdf/pyshorteners/latest/pyshorteners.pdf