### PR TITLE
changed link for pyshortener documentation to readthedocs.io from ell…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ For more information: [pytest](https://docs.pytest.org/en/latest/contents.html)
 
 
 ### Adding a new host
-This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](http://www.ellison.rocks/pyshorteners/)
+This project uses the pyshorteners library for url shortening, read their documentation for more information on implementing a new host: [pyshorteners](https://pyshorteners.readthedocs.io/en/latest/index.html)


### PR DESCRIPTION
…ison.rocks

(Ellison.rocks site looks like its ownership has lapsed; it's full of links to buy die cutting machines now)