### PR TITLE
Added copy icon next to the URL and Validate URL

### DIFF
--- a/Shortener/templates/shortener/home.html
+++ b/Shortener/templates/shortener/home.html
@@ -5,7 +5,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>UrlShortener</title>
-    <!--Include Bootstrap CSS-->
+	<!--Include Bootstrap CSS-->
+	<link
+	href="https://fonts.googleapis.com/icon?family=Material+Icons"
+	rel="stylesheet"
+  />
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 </head>
 
@@ -34,14 +38,41 @@
 	        </form>
         </div>
         <div class="row">
-        	<div class="text-center col-md-6 col-md-offset-3">
-				<h2>{{ short_url }}</h2>
-				{% if short_url %}
+        	<div class="text-center col-md-6 col-md-offset-3">			
+			
+				  <div style="display:flex; justify-content:center; align-items:center">
+				  {% if short_url %}
+					<h2 id="url">{{ short_url }}</h2> 
+					<span id="copy-icon"  style="cursor:pointer; margin-left:2rem;" title="Copy URL">
+						<i class="material-icons">content_copy</i>
+					</span>
+				  </div>
+
 					<img src="http://chart.apis.google.com/chart?cht=qr&chl={{ short_url }}&chs=180x180" />
+				{%else%}
+				</div>
 				{% endif %}
 			</div>
         </div>
     </div>
-</body>    
+</body>   
+
+
+
+{% comment %} Copy url to clipboard {% endcomment %}
+<script>
+	try{
+		text = document.getElementById("url").innerText;
+		document.getElementById("copy-icon").onclick = ()=>{
+			elem = document.createElement("textarea");
+			document.body.appendChild(elem);
+			elem.value = text;
+			elem.select();
+			document.execCommand("copy");
+			document.body.removeChild(elem);
+		}
+	}
+	catch(err){}
+</script>
 
 </html> 

--- a/Shortener/views.py
+++ b/Shortener/views.py
@@ -12,6 +12,9 @@ from rest_framework import status
 from .serializers import UrlAPISerializer
 from .services.rebrandly import Rebrandly
 from .services.madwire import Madwire
+from django.core.validators import URLValidator
+
+validate = URLValidator()
 # from pyshorteners.exceptions import UnknownShortenerException
 
 
@@ -20,6 +23,11 @@ GOOGLE_TOKEN = "AIzaSyCyj45kuk95kopaSuJ4NvErGMyTVV9i3n4"
 REBRANDLY_TOKEN = "b71d7dcfd2f14f0ca4f533bbd6fd226a"
 
 def worker(url, host):          # Madwire, Google, and Rebrandly no longer supported by pyshortener
+    try:                     #Check if the url is valid or not
+        validate(url)
+    except:
+        return "Invalid URL"
+
     shortener = Shortener()
     if host == "Bitly":
         shortener = Shortener(api_key=BITLY_TOKEN)


### PR DESCRIPTION
Added a copy icon so users can click the icon to copy the URL instead of manually copping it. 
Added URL validation to prevent invalid URLs. It prevents users to send invalid URL. It also handle the exception when user submits "https://" as URL.

![Screenshot from 2020-08-12 02-09-58](https://user-images.githubusercontent.com/34039975/89944214-3e094000-dc41-11ea-9baa-03a5c2a7f605.png)


_NB: This is my first OSS contribution._